### PR TITLE
🐛 Skipping certbot role when certbot_certs is not defined

### DIFF
--- a/collectionspace.yml
+++ b/collectionspace.yml
@@ -40,7 +40,7 @@
       tags: ['nginx', 'web']
     - role: certbot
       tags: ['certbot', 'certs']
-      when: certbot_certs | length > 0
+      when: certbot_certs is defined and certbot_certs | length > 0
 
   tasks:
     - name: Create CollectionSpace vhost config


### PR DESCRIPTION
Prevents an error in the playbook when certbot_certs is not defined (which is the default)