### PR TITLE
🐛 Playbook now fails if cspace version information is mismatched

### DIFF
--- a/aws-cspace.pkr.hcl
+++ b/aws-cspace.pkr.hcl
@@ -15,7 +15,7 @@ variable "ami_prefix" {
 // TODO: get this from vars
 variable "revision" {
   type    = string
-  default = "v7.0-branch"
+  default = "v7.1-branch"
 }
 
 variable "root_volume_size_gb" {
@@ -43,7 +43,7 @@ source "amazon-ebs" "ubuntu" {
 
   source_ami_filter {
     filters = {
-      name                = "ubuntu/images/*ubuntu-focal-20.04-amd64-server-*"
+      name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }

--- a/collectionspace.yml
+++ b/collectionspace.yml
@@ -5,6 +5,7 @@
   become: true
 
   pre_tasks:
+    - import_tasks: version_check.yml
     - import_tasks: includes/version.yml
     - name: Install packages
       apt:

--- a/includes/apt.yml
+++ b/includes/apt.yml
@@ -6,9 +6,9 @@
     state: present
     update_cache: true
   with_items:
-    - "deb http://us.archive.ubuntu.com/ubuntu jammy universe"
-    - "deb http://us.archive.ubuntu.com/ubuntu jammy-updates universe"
-    - "deb http://security.ubuntu.com/ubuntu jammy-security universe"
+    - "deb http://us.archive.ubuntu.com/ubuntu {{ ansible_distribution_release }} universe"
+    - "deb http://us.archive.ubuntu.com/ubuntu {{ ansible_distribution_release }}-updates universe"
+    - "deb http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security universe"
 
 - name: Update and upgrade apt packages
   apt:

--- a/includes/apt.yml
+++ b/includes/apt.yml
@@ -1,5 +1,15 @@
 ---
 
+- name: Ensure the universe repository is present
+  ansible.builtin.apt_repository:
+    repo: "{{ item }}"
+    state: present
+    update_cache: true
+  with_items:
+    - "deb http://us.archive.ubuntu.com/ubuntu jammy universe"
+    - "deb http://us.archive.ubuntu.com/ubuntu jammy-updates universe"
+    - "deb http://security.ubuntu.com/ubuntu jammy-security universe"
+
 - name: Update and upgrade apt packages
   apt:
     upgrade: true
@@ -19,4 +29,4 @@
     dest: /etc/apt/apt.conf.d/10periodic
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,8 +2,6 @@
 
 collections:
 - name: community.general
-  version: latest
-  source: https://galaxy.ansible.com
 
 roles:
 - src: https://github.com/geerlingguy/ansible-role-certbot.git

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,11 @@
 ---
 
+collections:
+- name: community.general
+  version: latest
+  source: https://galaxy.ansible.com
+
+roles:
 - src: https://github.com/geerlingguy/ansible-role-certbot.git
   name: certbot
   version: 5.0.1

--- a/version_check.yml
+++ b/version_check.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Get the version of CollectionSpace from Packer
+  ansible.builtin.slurp:
+    src: "{{ playbook_dir }}/aws-cspace.pkr.hcl"
+  register: cspace_packer_file
+  delegate_to: localhost
+
+- name: Get the version of CollectionSpace from the Ansible role
+  ansible.builtin.slurp:
+    src: "{{ playbook_dir }}/roles/collectionspace/defaults/main.yml"
+  register: cspace_role_file
+  delegate_to: localhost
+
+- name: Set version variables from files
+  ansible.builtin.set_fact:
+    cspace_packer_version: "{{ cspace_packer_file.content | b64decode | regex_findall('default = \"v([^\"]+)\"') | first }}"
+    cspace_role_version: "{{ cspace_role_file.content | b64decode | regex_findall('collectionspace_revision: v([^ ]+)') | first }}"
+
+- name: Show versions
+  ansible.builtin.debug:
+    msg:
+      - "CollectionSpace version from aws-cspace.pkr.yml: {{ cspace_packer_version }}"
+      - "CollectionSpace version from roles/collectionspace/defaults/main.yml: {{ cspace_role_version }}"
+
+- name: Verify that CollectionSpace versions are identical
+  ansible.builtin.fail:
+    msg:
+      - "Conflicting CollectionSpace versions found, ensure versions are the same in:"
+      - "aws-cspace.pkr.yml"
+      - "roles/collectionspace/defaults/main.yml"
+  when: cspace_packer_version != cspace_role_version


### PR DESCRIPTION
Fixes an issue where mismatched variables either built the wrong version or created AMIs with incorrect names.

AMI build was intermittently failing due to being unable to find fail2ban in the package repository. Resolved by making sure the universe repo is enabled, but also adds a hardcoded string that requires updating for new versions of Ubuntu.