### PR TITLE
📝 Updating docs to remove references to ES tmpdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,6 @@ Operating System a few times before settling on a final configuration
 
 See the [documentation](docs/README.md) for full instructions.
 
-## Role gotchas
-
-Elasticsearch role update line#95 in `./roles/elasticsearch/templates/jvm.options.j2`:
-
-```
--Djava.io.tmpdir=/tmp # replaces: -Djava.io.tmpdir={ES_TMPDIR}
-```
-
 ## Developer Quickstart
 
 Add `ServerAliveInterval 120` to your `~/.ssh/config` then create `vars/deploy.yml`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,10 +97,6 @@ cd cspace-installer
 ansible-galaxy install -r requirements.yml --force
 ```
 
-Before proceeding check for any [role gotchas](../README.md#role-gotchas)
-(workarounds that are required pending review of a more permanent
-solution).
-
 ## Running Ansible
 
 For Ansible to setup CollectionSpace on your server you will need to


### PR DESCRIPTION
The workaround mentioned in the docs was resolved by a patch in the role applied in #36 